### PR TITLE
Trim license and tech info from downloaded books.

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -393,9 +393,17 @@ from a gutenberg book."
 
 START and END allow to limit to a buffer section - they default
 to (point-min) and (point-max)"
-  (unless start (setq start (point-min)))
-  (unless end (setq end (point-max)))
   (save-mark-and-excursion
+    (when (search-forward "*** START" nil t)
+      (end-of-line 1)
+      (setq start (point)))
+    (when (search-forward "*** END" nil t)
+      (beginning-of-line 1)
+      (setq end (point)))
+
+    (unless start (setq start (point-min)))
+    (unless end (setq end (point-max)))
+   
     (goto-char start)
     (forward-paragraph
      ;; count the paragraphs, and pick a random one

--- a/speed-type.el
+++ b/speed-type.el
@@ -386,17 +386,13 @@ from a gutenberg book."
 
 START and END allow to limit to a buffer section - they default
 to (point-min) and (point-max)"
-  (save-mark-and-excursion
-    (when (search-forward "*** START" nil t)
-      (end-of-line 1)
-      (setq start (point)))
-    (when (search-forward "*** END" nil t)
-      (beginning-of-line 1)
-      (setq end (point)))
+  (unless start (setq start (point-min)))
+  (unless end (setq end (point-max)))
 
-    (unless start (setq start (point-min)))
-    (unless end (setq end (point-max)))
-   
+  ;; TEST
+  (message "Points are %s %s" start end)
+  
+  (save-mark-and-excursion
     (goto-char start)
     (forward-paragraph
      ;; count the paragraphs, and pick a random one
@@ -445,12 +441,15 @@ will be used. Else some text will be picked randomly."
       (speed-type--setup (speed-type--pick-text-to-type))
       (setq speed-type--opened-on-buffer buf))))
 
+;; TEST
+(setq book-num-test-counter 0)
+
 ;;;###autoload
 (defun speed-type-text ()
   "Setup a new text sample to practice touch or speed typing."
   (interactive)
-  (let ((book-num (nth (random (length speed-type-gb-book-list))
-                       speed-type-gb-book-list))
+  (let ((book-num (nth book-num-test-counter ;; (random (length speed-type-gb-book-list))
+		       speed-type-gb-book-list))
         (author nil)
         (title nil))
     (with-temp-buffer
@@ -461,9 +460,33 @@ will be used. Else some text will be picked randomly."
       (when (re-search-forward "^Author: " nil t)
         (setq author (buffer-substring (point) (line-end-position))))
 
-      (speed-type--setup (speed-type--pick-text-to-type (point))
-                         author title))))
+      (let ((start (point))
+	    (end nil))
+	(goto-char 0)
+	(when (re-search-forward "***.START.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)
+	  (end-of-line 1)
+	  (setq start (point))
+	  ;; TEST
+	  (message "FOUND START")
+	  )
+	(when (re-search-forward "***.END.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)	
+  (beginning-of-line 1)
+	  (setq end (point))
+	  ;; TEST
+	  (message "FOUND END")
+	  )
+
+	(setq book-num-test-counter (+ book-num-test-counter 1))
+
+	;; TEST
+	(message "Book num %s: Starting point is %s %s" book-num start end)
+
+	(speed-type--setup (speed-type--pick-text-to-type start end)
+			   author title)))))
 
 (provide 'speed-type)
 
 ;;; speed-type.el ends here
+
+;; TEST
+;; FILE NOT FOUND: 829, 768, 521

--- a/speed-type.el
+++ b/speed-type.el
@@ -389,9 +389,6 @@ to (point-min) and (point-max)"
   (unless start (setq start (point-min)))
   (unless end (setq end (point-max)))
 
-  ;; TEST
-  (message "Points are %s %s" start end)
-  
   (save-mark-and-excursion
     (goto-char start)
     (forward-paragraph
@@ -441,14 +438,11 @@ will be used. Else some text will be picked randomly."
       (speed-type--setup (speed-type--pick-text-to-type))
       (setq speed-type--opened-on-buffer buf))))
 
-;; TEST
-(setq book-num-test-counter 0)
-
 ;;;###autoload
 (defun speed-type-text ()
   "Setup a new text sample to practice touch or speed typing."
   (interactive)
-  (let ((book-num (nth book-num-test-counter ;; (random (length speed-type-gb-book-list))
+  (let ((book-num (nth (random (length speed-type-gb-book-list))
 		       speed-type-gb-book-list))
         (author nil)
         (title nil))
@@ -462,24 +456,16 @@ will be used. Else some text will be picked randomly."
 
       (let ((start (point))
 	    (end nil))
-	(goto-char 0)
+
+	(goto-char (point-min))
 	(when (re-search-forward "***.START.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)
 	  (end-of-line 1)
-	  (setq start (point))
-	  ;; TEST
-	  (message "FOUND START")
-	  )
-	(when (re-search-forward "***.END.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)	
-  (beginning-of-line 1)
-	  (setq end (point))
-	  ;; TEST
-	  (message "FOUND END")
-	  )
-
-	(setq book-num-test-counter (+ book-num-test-counter 1))
-
-	;; TEST
-	(message "Book num %s: Starting point is %s %s" book-num start end)
+	  (forward-line 1)
+	  (setq start (point)))
+	(when (re-search-forward "***.END.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)
+	  (beginning-of-line 1)
+	  (forward-line -1)
+	  (setq end (point)))
 
 	(speed-type--setup (speed-type--pick-text-to-type start end)
 			   author title)))))
@@ -487,6 +473,3 @@ will be used. Else some text will be picked randomly."
 (provide 'speed-type)
 
 ;;; speed-type.el ends here
-
-;; TEST
-;; FILE NOT FOUND: 829, 768, 521


### PR DESCRIPTION
Fixes issue https://github.com/hagleitn/speed-type/issues/10 from the old repo.

In this fix:
Each Gutenberg Ebook has the lines:

`*** START OF THIS PROJECT GUTENBERG EBOOK ...` or `*** START OF THE PROJECT GUTENBERG EBOOK ...`

and 

`*** END OF THIS PROJECT GUTENBERG EBOOK ...` or `*** START OF THE PROJECT GUTENBERG EBOOK ...`

The content of a Gutenberg ebook is in between these lines. Outside these lines contain license and tech info that are not part of the book and are trimmed so that they are not picked.

If there are no such lines, the `START` and `END` defaults to `(point-min)` and `(point-max)`.