### PR TITLE
Fix always retrieving the German wordlist when loading the library

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -245,8 +245,6 @@ Accuracy is computed as (CORRECT-ENTRIES - CORRECTIONS) / TOTAL-ENTRIES."
   "Return buffer with wordlist for language LANG in it."
   (speed-type--retrieve lang (cdr (assoc lang speed-type-wordlist-urls))))
 
-(speed-type--wordlist-retrieve 'German)
-
 (defun speed-type--elapsed-time ()
   "Return float with the total time since start."
   (let ((end-time (float-time)))


### PR DESCRIPTION
When adding the wordlist feature I left a "debug" statement
in the root scope to test the wordlist-retrieve function.
This now causes to always load the German wordlist when only
loading speed-type even though the user might not even be interested
in it.